### PR TITLE
Initial report script - provides info in test results and annotations

### DIFF
--- a/scripts/src/chartprreview/verify-report.sh
+++ b/scripts/src/chartprreview/verify-report.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+
+getAnnotations() {
+
+  report=$1
+
+  annotations=()
+
+  metadata=false
+  tool=false
+  chart=false
+  chartannotations=false
+
+
+  while IFS= read -r line; do
+    line=`echo $line | xargs`
+    if [[ $line == "metadata:"* ]]; then
+      metadata=true
+    elif [[ $line == "results:"* ]]; then
+      metadata=false
+    elif [ "$metadata" = true ]; then
+      if [[ $line == *"tool:" ]]; then
+          tool=true
+          chart=false
+      elif [[ $line == *"chart:" ]]; then
+          tool=false
+          chart=true
+      elif [ "$tool" = true ]; then
+        if [[ $line == "digest:"* ]]; then
+            digest=`echo "$line" | sed 's/digest://' | xargs`
+            annotations+=("\"helm-chart.openshift.io/digest\":\"$digest\"")
+        elif [[ $line == "lastCertifiedTime:"* ]]; then
+            certtime=`echo "$line" | sed 's/lastCertifiedTime://' | xargs`
+            annotations+=("\"helm-chart.openshift.io/lastCertifiedTime\":\"$certtime\"")
+        fi
+      elif [ "$chart" = true ]; then
+        if [[ $line == "annotations:"* ]]; then
+            chartannotations=true
+        elif [ "$chartannotations" = true ]; then
+          if [[ $line == "helm-chart.openshift.io/"* ]]; then
+             name=`echo $line | cut -d: -f1 | xargs`
+             value=`echo "$line" | sed "s#$name:##" | xargs`
+             annotations+=("\"$name\":\"$value\"")
+          fi
+        fi
+      fi
+    fi
+
+  done < $report
+
+  output="{"
+  addComma=false
+  for annotation in "${annotations[@]}"; do
+    if [ "$addComma" = true ]; then
+      output+=", "
+    fi
+    output+="$annotation"
+    addComma=true
+  done
+  output+="}"
+
+  echo $output
+}
+
+getFails () {
+
+  report=$1
+
+  results=false
+  fails=()
+  passed=0
+
+  while IFS= read -r line; do
+
+    if [[ ! -z $line ]]; then
+      if [[ $line == "results:"* ]]; then
+        results=true
+      elif [ "$results" = true ]; then
+        if [[ $line == *" - "* ]]; then
+            multireason=false
+            check=""
+            type=""
+            outcome=""
+            reason=""
+        fi
+        if [[ $line == *"check:"* ]]; then
+           check=`echo $line | cut -d: -f2 | xargs`
+        elif [[ $line == *"type:"* ]]; then
+           type=`echo $line | cut -d: -f2 | xargs`
+        elif [[ $line == *"outcome:"* ]]; then
+           outcome=`echo $line | cut -d: -f2 | xargs`
+        elif [[ $line == *"reason:"* ]]; then
+           reason=`echo $line | cut -d: -f2 | xargs`
+           if [[ $reason == *'-' ]]; then
+             multireason=true
+             reason=""
+           fi
+        elif [ "$multireason" = true ]; then
+           reason=`echo $line | xargs`
+        fi
+
+        if [ -n "$check" ] && [ -n "$type" ] && [ -n "$outcome" ] && [ -n "$reason" ]; then
+          if [[ $outcome != "PASS" ]] && [[ $type == "Mandatory" ]]; then
+              fails+=("$reason")
+          else
+            passed=$((passed+1))
+          fi
+        fi
+      fi
+    fi
+  done < $report
+
+  output="{\"passed\": $passed, \"failed\": ${#fails[@]}"
+  if [ ${#fails[@]} -gt 0 ]; then
+      output+=", \"message\": ["
+      addComma=false
+      for fail in "${fails[@]}"; do
+        if [ "$addComma" = true ]; then
+          output+=","
+        fi
+        output+="\"$fail\""
+        addComma=true
+      done
+  fi
+  output+="]}"
+  echo $output
+
+}
+
+command=$1
+report=$2
+chart=$3
+
+if [ -z "$report" ]; then
+  echo "{\"error\": \"report must be specified\"}"
+  exit
+fi
+
+if [ ! -f "$report" ]; then
+  echo "{\"error\": \"report does not exist\"}"
+  exit
+fi
+
+
+if [ $command == "results" ]; then
+  getFails "$report"
+elif  [ $command == "annotations" ]; then
+  getAnnotations "$report"
+else
+  echo "{\"error\": \"$command is not a valid command\"}"
+fi
+


### PR DESCRIPTION
Run as:

```verify-report.sh results <report file> <chart location>```
or
```verify-report.sh annotations <report file> <chart location>```

output is in json format.  Example outputs

result passing report : 
```{"passed": 9, "failed": 0}```

results report with 2 errors, message separated by # :
 ```{"passed": 9, "failed": 2, "message": ["Image is Red Hat certified : nginx:latest","Image is Red Hat certified : snyk/kubernetes-operator"]}```

annotations report:
```{"helm-chart.openshift.io/digest":"sha256:87d80d75cf0e66c8f7b7fe7deb2f532d7ae44f6cee97c69c9c9bfe552ab8dfb5", "helm-chart.openshift.io/lastCertifiedTime":"2021-04-21 17:04:21.627985 -0400 EDT m=+1.597196131", "helm-chart.openshift.io/archs":"all", "helm-chart.openshift.io/name":"get your awesomeness here", "helm-chart.openshift.io/provider":"acme", "helm-chart.openshift.io/supportURL":"http://acme-help-is-here.com/"}```

bad invocation: 
```{"error": "report must be specified"}```
