### PR TITLE
allow for annotation rename : lastCertifiedTimestamp

### DIFF
--- a/scripts/src/chartprreview/verify-report.sh
+++ b/scripts/src/chartprreview/verify-report.sh
@@ -29,9 +29,12 @@ getAnnotations() {
         if [[ $line == "digest:"* ]]; then
             digest=`echo "$line" | sed 's/digest://' | xargs`
             annotations+=("\"helm-chart.openshift.io/digest\":\"$digest\"")
+        elif [[ $line == "lastCertifiedTimestamp:"* ]]; then
+            certtime=`echo "$line" | sed 's/lastCertifiedTimestamp://' | xargs`
+            annotations+=("\"helm-chart.openshift.io/lastCertifiedTimestamp\":\"$certtime\"")
         elif [[ $line == "lastCertifiedTime:"* ]]; then
             certtime=`echo "$line" | sed 's/lastCertifiedTime://' | xargs`
-            annotations+=("\"helm-chart.openshift.io/lastCertifiedTime\":\"$certtime\"")
+            annotations+=("\"helm-chart.openshift.io/lastCertifiedTimestamp\":\"$certtime\"")
         fi
       elif [ "$chart" = true ]; then
         if [[ $line == "annotations:"* ]]; then


### PR DESCRIPTION
Updated the script to allow for renaming of LastCertifiedTime in the report to LastCertifiedTimestamp.

To allow for a lag between getting reports with  LastCertifiedTimestamp the script recognizes both for now. If it does get LastCertifiedTime it writes in out as LastCertifiedTimestamp, so ODC will  be correct.